### PR TITLE
Expand toggles & menu

### DIFF
--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -450,7 +450,9 @@ header {
     position: fixed;
     top: 0;
     width: 100%;
-    display: grid;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 
     text-align: center;
     font-size: var(--font-size-label);
@@ -512,32 +514,39 @@ header.scrolled {
     align-items: center;
     padding: var(--padding);
     gap: var(--v-spacing);
+
 }
 
 .expanded-header {
-    margin: auto;
+    --_expanded-header-width: 22.8em;
+
+    position: absolute;
     height: 0;
     padding: 0;
     overflow: hidden;
-    max-width: var(--max-site-width, 1920px);
     width: 100%;
-    gap: calc(var(--v-spacing) * 2);
+    max-width: var(--max-site-width, 1920px);
     transition: all 0.3s;
+    top: var(--header-height);
 }
 
 .expanded-header:has(.active) {
-    height: fit-content;
     display: flex;
+    height: fit-content;
+    flex-direction: column;
     justify-content: end;
     align-items: end;
-    padding: var(--padding);
+    padding: var(--padding) 0;
 }
 
 @media screen and (max-width: 930px) {
     .expanded-header:has(.active) {
+        --_expanded-header-width: 100%;
+        position: static;
         height: calc(100dvh - var(--header-height));
         flex-direction: column;
         justify-content: space-between;
+        gap: calc(var(--v-spacing) * 2);
     }
 }
 
@@ -545,24 +554,45 @@ header.scrolled {
     display: flex;
     flex-direction: column;
     gap: var(--v-spacing);
-    width: 100%;
     justify-content: end;
+}
+
+@media screen and (min-width: 930px) {
+
+    .expanded-header > .active {
+        background: var(--_header-background);
+        padding: var(--padding);
+        margin-right: var(--padding);
+    }
+    
 }
 
 .expanded-header > *:not(.active) {
     display: none;
 }
 
-.expanded-header .sub-menu {
-    margin-right: 4em;
-}
-
 nav, nav ul {
-    --_nav-spacing: var(--h-spacing);
+    --_nav-spacing: var(--v-spacing);
 
     display: flex;
     gap: var(--_nav-spacing);
     align-items: center;
+}
+
+.sub-menu {
+    flex-direction: column;
+    align-items: start;
+}
+
+@media screen and (min-width: 930px) {
+    .sub-menu {
+        width: var(--_expanded-header-width);
+    }
+
+    header input[type="search"] {
+        width: var(--_expanded-header-width);
+    }
+    
 }
 
 @media screen and (max-width: 930px) {
@@ -601,7 +631,11 @@ input[type="search"]:focus, input[type="number"]:focus, input[type="text"]:focus
 
 @media screen and (min-width: 930px) {
     header form.active input[type="search"] {
-        width: 37.15em; /* Same width as main-menu */
+        width: 35.8em;
+    }
+
+    header form.active:has(+ .expanded-menu.active) input[type="search"] {
+        width: var(--_expanded-header-width); /* Same width as main-menu */
     }
 }
 
@@ -658,6 +692,7 @@ label:focus-within, label:has(button):hover, label:has(button.active) {
 @media screen and (max-width: 930px) {
     .expanded-menu {
         align-items: center;
+        width: var(--_expanded-header-width);
     }
 }
 
@@ -1142,12 +1177,12 @@ div:has(>.filter-expansion) {
     display: grid;
 }
 
-div:has(button.active) .filter-expansion {
+div:has(button.active)>.filter-expansion {
     border-top: var(--line-thickness) solid var(--color-primary);
 }
 
 @media screen and (min-width: 930px) {
-    div:has(button.active) .filter-expansion {
+    div:has(button.active)>.filter-expansion {
         border: var(--line-thickness) solid var(--color-primary);
     }
 

--- a/lib/javascript/menu-toggle.js
+++ b/lib/javascript/menu-toggle.js
@@ -1,23 +1,46 @@
-window.addEventListener('resize', () => activateHamburgerOnResize('expanded-hamburger', 930));
+window.addEventListener('resize', () => activateHamburgerOnResize('.expanded-hamburger', 930));
 
+// open/close targets of clicked '.toggle-button' + constraints for specific toggles
 document.querySelectorAll('.toggle-button').forEach(button => {
-    button.addEventListener('click', () => {
+    button.addEventListener('click', (e) => {
+        e.stopPropagation();
         if (button.classList.contains('filter')) {
             removeActiveState(`.filter-expansion:not(${button.getAttribute('aria-controls')})`)
         }
+        if(button.classList.contains('menu-item') || button.getAttribute('aria-controls').includes('preview-search')) {
+            removeActiveState(`.expanded-hamburger:not(${button.getAttribute('aria-controls')})`);
+        }
+
         toggleActiveState(button.getAttribute('aria-controls'), button.dataset.focusNext);
+        syncExpandedState('.toggle-button');
+        toggleMenuIcon();
+        
         if (button.getAttribute('aria-controls') === '.date-filter') {
             scrollToSelected('.wheel-select.date-filter-select');
         }
-        toggleExpandedStateIfActive(button, button.getAttribute('aria-controls'));
+    });
+});
+
+// Close expanded menu when selecting a menu point
+document.querySelectorAll('.expanded-header a').forEach(button => {
+    button.addEventListener('click', (e) => {
+        e.stopPropagation();
+        removeActiveState('.expanded-hamburger');
+        syncExpandedState('.toggle-button');
+        toggleMenuIcon();
     });
 });
 
 function toggleActiveState(selector, setFocusOn = null) {
     document.querySelectorAll(selector).forEach((elem) => {
+        window.addEventListener('click', (e) => {
+            if (!elem.contains(e.target)) {
+                elem.classList.remove('active');
+                syncExpandedState('.toggle-button');
+            }
+        });
         elem.classList.toggle('active');
     });
-    miesSchlechteLoesung(selector);
     if (setFocusOn != null || setFocusOn !== undefined) {
         document.querySelector(setFocusOn)?.focus();
     }
@@ -42,21 +65,6 @@ function removeActiveState(selector, setFocusOn = null) {
     }
 }
 
-function miesSchlechteLoesung(selector) {
-    if (selector === '.preview-search') {
-        let temp = document.getElementById('expanded-menu').classList;
-        if (temp.contains('active')) temp.remove('active');
-    } else if (selector === '.expanded-menu') {
-        let temp = document.getElementById('preview-search').classList;
-        if (temp.contains('active')) {
-            temp.remove('active');
-        }
-    }
-    if (selector === '.expanded-hamburger' || selector === '.expanded-menu' || selector === '.preview-search') {
-        toggleMenuIcon();
-    }
-}
-
 function toggleMenuIcon() {
     if (document.querySelector('.expanded-hamburger').classList.contains('active')
         || document.querySelector('.expanded-menu').classList.contains('active')) {
@@ -71,19 +79,22 @@ function toggleMenuIcon() {
 function activateHamburgerOnResize(selector, breakpoint, targetBelow = true) {
     if (targetBelow) {
         if (window.innerWidth <= breakpoint
-            && document.getElementById('preview-search').classList.contains('active')
-            || document.getElementById('expanded-menu').classList.contains('active')) addActiveState(selector);
+            && document.querySelector('#preview-search-form').classList.contains('active')
+            || document.querySelector('#expanded-menu').classList.contains('active')) addActiveState(selector);
     } else {
         if (window.innerWidth >= breakpoint
-            && document.getElementById('preview-search').classList.contains('active')
-            || document.getElementById('expanded-menu').classList.contains('active')) addActiveState(selector);
+            && document.querySelector('#preview-search-form').classList.contains('active')
+            || document.querySelector('#expanded-menu').classList.contains('active')) addActiveState(selector);
     }
 }
 
-function toggleExpandedStateIfActive(button, conditionalSelector) {
-    if (document.querySelector(conditionalSelector).classList.contains('active')) {
-        button.classList.add('expanded');
-    } else {
-        button.classList.remove('expanded');
-    }
+function syncExpandedState(buttonSelector) {
+    buttons = document.querySelectorAll(buttonSelector);
+    buttons.forEach(button => {
+        if (document.querySelector(button.getAttribute('aria-controls')).classList.contains('active')) {
+            button.classList.add('expanded');
+        } else {
+            button.classList.remove('expanded');
+        }
+    });
 }


### PR DESCRIPTION
- fixed #78 
- fixed #102 
- implemented #92 
- dropdowns now close when clicking anywhere

Feedback for header dropdown styling would be nice
(if it's only about tiny spacing or padding decisions - they will change with #19)

Attention:
- "Über die Studiengänge" sub menu is aligned with "Über die Studiengänge"
- "search" is aligned with "Übersicht & Beiträge"
- if both are active (e.g. because of resizing from hamburger menu), both are aligned with "Über die Studiengänge"