### PR TITLE
Revision of spacings, paddings and font-sizes

### DIFF
--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -56,74 +56,6 @@
     --color-lavender-600: #9c68a2;
     --color-lavender-700: #b58bba;
     --color-lavender-900: #e2d0e4;
-
-    /* Typography */
-
-    --font-family: "Helvetica Neue", "Arial", sans-serif;
-    --font-size-mobile: 16px;
-    --font-size-large: 20px;
-    --font-size: var(--font-size-mobile);
-    --line-height: 1.5;
-    --button-size: 2.4rem;
-
-    --font-size-title: 2.8rem;
-    --font-size-headline1: 2.4rem;
-    --font-size-headline2: 1.8rem;
-    --font-size-headline3: 1.2rem;
-    --font-size-card-title: 1rem;
-    --font-size-body: 1rem;
-    --font-size-label: 0.8rem;
-
-    font-size: var(--font-size);
-
-    --fontweight-light: 300;
-    --fontweight-body: 400;
-    --fontweight-headline: 500;
-    --fontweight-title: bold;
-    --line-height-headline: 1.2;
-
-    /* Spacings & Paddings */
-
-    --unit: 8px;
-
-    --padding-mobile: 1rem;
-    --padding-tablet: 2rem;
-    --padding-large: 3rem;
-
-    --padding: clamp(var(--padding-mobile), 1vw, var(--padding-large));
-
-    --h-spacing-mobile: 24px;
-    --h-spacing-tablet: 32px;
-    --h-spacing-large: 48px;
-
-    --h-spacing: clamp(var(--h-spacing-mobile), 5vw, var(--h-spacing-large));
-    --h-spacing-small: calc(var(--h-spacing) / 2);
-
-    --v-spacing-mobile: 40px;
-    --v-spacing-large: 48px;
-
-    --v-spacing: var(--v-spacing-mobile);
-    --v-spacing-small: calc(var(--v-spacing) / 2);
-
-    --v-spacing-previews-mobile: 72px;
-    --v-spacing-previews-large: 80px;
-
-    --v-spacing-previews: var(--v-spacing-previews-mobile);
-
-    --header-height: 88px;
-
-    --content-wrap: 1120px;
-
-    --max-site-width: 1920px;
-
-    /* Styling */
-
-    --line-thickness: 2px;
-
-    --button-size: 2.4rem;
-    --border-radius-interaction: calc(var(--button-size) / 2);
-
-    --elevation-1: 0px 0px 4px rgba(0, 0, 0, 0.1);
 }
 
 .minf {
@@ -145,6 +77,103 @@
     }
 }
 
+:root {
+    /* Typography */
+    --font-family: "Helvetica Neue", "Arial", sans-serif;
+    --font-size-mobile: 100%;
+    --font-size-large: 110%;
+    --font-size: var(--font-size-mobile);
+    --line-height: 1.5;
+    --button-size: 2.4rem;
+
+    --font-size-title: 2.8rem;
+    --font-size-headline1: 2.4rem;
+    --font-size-headline2: 1.8rem;
+    --font-size-headline3: 1.2rem;
+    --font-size-card-title: 1rem;
+    --font-size-body: 1rem;
+    --font-size-label: 0.8rem;
+
+    font-size: var(--font-size);
+
+    --fontweight-light: 300;
+    --fontweight-body: 400;
+    --fontweight-headline: 500;
+    --fontweight-title: bold;
+    --line-height-headline: 1.2;
+}
+
+@media (min-width: 600px) {
+    :root {
+        --font-size: var(--font-size-large);
+    }
+}
+
+:root {
+    /* Spacings & Paddings */
+    --unit: 8px;
+
+    --edge-padding-s: calc(var(--unit) * 3);
+    --edge-padding-m: calc(var(--unit) * 4);
+    --edge-padding-l: calc(var(--unit) * 6);
+    --edge-padding: var(--edge-padding-s);
+
+    --padding-s: 1rem;
+    --padding-m: 2rem;
+    --padding-l: 3rem;
+
+    --padding: clamp(var(--padding-s), 1vw, var(--padding-l));
+
+    --h-spacing-s: var(--edge-padding-s);
+    --h-spacing-m: var(--edge-padding-m);
+    --h-spacing-l: var(--edge-padding-l);
+
+    --h-spacing: var(--h-spacing-s);
+    --h-spacing-small: calc(var(--h-spacing) / 2);
+
+    --v-spacing-s: calc(var(--unit) * 5);
+    --v-spacing-l: calc(var(--unit) * 6);
+
+    --v-spacing: var(--v-spacing-s);
+    --v-spacing-half: calc(var(--v-spacing) / 2);
+
+
+    --section-spacing: calc(var(--v-spacing) * 2);
+
+    --v-spacing-previews: calc(var(--v-spacing) * 2);
+
+    --header-height: calc(var(--unit) * 11);
+
+    --content-wrap: 1120px;
+
+    --max-site-width: 1920px;
+
+    /* Styling */
+
+    --line-thickness: 2px;
+
+    --button-size: 2.4rem;
+    --border-radius-interaction: calc(var(--button-size) / 2);
+
+    --elevation-1: 0px 0px 4px rgba(0, 0, 0, 0.1);
+}
+
+@media (min-width: 600px) {
+    :root {
+        --edge-padding: var(--edge-padding-m);
+        --h-spacing: var(--h-spacing-m);
+
+        --v-spacing: var(--v-spacing-l);
+    }
+}
+
+@media (min-width: 930px) {
+    :root {
+        --edge-padding: var(--edge-padding-l);
+        --h-spacing: var(--h-spacing-l);
+    }
+}
+
 
 .minf .no-prefilter, .musk .no-prefilter, html .prefilter-minf, html .prefilter-musk {
     display: none;
@@ -152,16 +181,6 @@
 
 .no-prefilter, .minf .prefilter-minf, .musk .prefilter-musk {
     display: block;
-}
-
-
-@media (min-width: 600px) {
-    :root {
-        --font-size: var(--font-size-large);
-        --v-spacing: var(--v-spacing-large);
-        --v-spacing-previews: var(--v-spacing-previews-large);
-        --font-size-label: 0.8rem;
-    }
 }
 
 /* Main Layout */
@@ -190,7 +209,7 @@ body {
 }
 
 .wrapping-grid {
-    --_padding-inline: var(--padding);
+    --_padding-inline: var(--edge-padding);
     --_content-max-width: var(--content-wrap);
     --_breakout-max-width: 85ch;
 
@@ -210,7 +229,7 @@ body {
             1fr
         )
         [full-end];
-    gap: var(--h-spacing) 0;
+    gap: var(--section-spacing) 0;
 }
 
 .wrapping-grid > *:not(.breakout), .wrapping-grid > *:not(.full) {
@@ -235,7 +254,7 @@ body {
     grid-column: span 4;
     display: flex;
     flex-direction: column;
-    gap: var(--v-spacing-small);
+    gap: var(--v-spacing-half);
 }
 
 .content-table {
@@ -272,7 +291,7 @@ body {
     .content-table {
         display: flex;
         flex-direction: row;
-        gap: var(--v-spacing-small);
+        gap: var(--v-spacing-half);
         list-style: none inside;
     }
 
@@ -392,7 +411,7 @@ h2 {
 }
 
 h3 {
-    margin-block-start: var(--v-spacing-small);
+    margin-block-start: var(--v-spacing-half);
     font-size: var(--font-size-headline3);
     font-weight: var(--fontweight-headline);
     line-height: var(--line-height-headline);
@@ -401,7 +420,7 @@ h3 {
 form {
     display: flex;
     flex-direction: column;
-    gap: var(--v-spacing-small);
+    gap: var(--v-spacing-half);
 }
 
 input[type="range"] {
@@ -510,7 +529,7 @@ header.scrolled {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding: var(--padding);
+    padding: calc(var(--unit) * 2) var(--edge-padding);
     gap: var(--v-spacing);
 }
 
@@ -530,7 +549,7 @@ header.scrolled {
     display: flex;
     justify-content: end;
     align-items: end;
-    padding: var(--padding);
+    padding: var(--edge-padding);
 }
 
 @media screen and (max-width: 930px) {
@@ -759,6 +778,10 @@ section {
     gap: var(--v-spacing);
 }
 
+section > *:first-child {
+    margin-block-start: 0;
+}
+
 label {
     font-size: var(--font-size-label);
 }
@@ -867,12 +890,12 @@ button:disabled {
 }
 
 .floating-actions > * {
-    margin-right: var(--h-spacing);
+    margin-right: calc(var(--edge-padding) - var(--unit));
     pointer-events: auto;
 }
 
 .snack-bar {
-    --_snack-bar-margin: var(--padding);
+    --_snack-bar-margin: var(--edge-padding);
 
     position: fixed;
     bottom: 0;
@@ -881,9 +904,8 @@ button:disabled {
     width: calc(100% - (var(--_snack-bar-margin) * 2));
     background: var(--color-container);
     filter: drop-shadow(var(--elevation-1));
-    padding: 0.6rem;
-    padding-inline: 1rem;
-    margin: var(--padding);
+    padding: 0.6rem var(--padding);
+    margin: var(--_snack-bar-margin);
     border-radius: var(--border-radius-interaction);
     justify-self: center;
 
@@ -903,7 +925,7 @@ button:disabled {
 
 footer {
     margin-block-start: calc(var(--v-spacing) * 2);
-    margin-block-end: var(--v-spacing-small);
+    margin-block-end: var(--v-spacing-half);
     padding: var(--padding) 0;
     font-size: var(--font-size-label);
 }
@@ -913,7 +935,7 @@ footer a:not(:hover, :focus) {
 }
 
 footer .content-grid {
-    gap: var(--v-spacing-small);
+    gap: var(--v-spacing-half);
 }
 
 .footer-column {
@@ -931,7 +953,7 @@ footer .content-grid {
     .footer-column {
         grid-column: 1 / -2 !important;
         flex-direction: column;
-        gap: var(--v-spacing-small);
+        gap: var(--v-spacing-half);
     }
 }
 
@@ -968,6 +990,10 @@ section.hero.wrapping-grid > .content-grid {
     position: absolute;
     width: 100%;
     height: 100%;
+}
+
+section#welcome-section {
+    margin-top: calc((var(--section-spacing) / -2) - var(--unit));
 }
 
 .website-title {
@@ -1106,8 +1132,10 @@ div:has(>.filter-expansion) {
 
         border-top: var(--line-thickness) solid var(--color-text);
         border-radius: 0;
-        padding-block-start: calc(var(--button-size) + var(--padding) + var(--v-spacing));
-        padding-block-end: calc(var(--v-spacing) + var(--padding));
+        padding:    calc(var(--button-size) + var(--padding) + var(--v-spacing)) 
+                    var(--edge-padding) 
+                    calc(var(--v-spacing) + var(--padding)) 
+                    var(--edge-padding);
     }
 
     #course-filter {
@@ -1155,7 +1183,7 @@ div:has(button.active) .filter-expansion {
 
 .filter-expansion > label {
     display: grid;
-    gap: var(--v-spacing-small);
+    gap: var(--v-spacing-half);
     justify-items: center;
     align-items: start;
     height: fit-content;
@@ -1208,7 +1236,7 @@ div:has(button.active) .filter-expansion {
 
 label:has(.wheel-select) {
     display: grid;
-    gap: var(--v-spacing-small);
+    gap: var(--v-spacing-half);
     justify-items: start;
     align-items: start;
 }
@@ -1443,6 +1471,7 @@ main.wrapping-grid {
     width: 100%;
     height: 60vh;
     object-fit: cover;
+    margin-block-end: var(--v-spacing);
 }
 
 .title-img-container {
@@ -1571,7 +1600,6 @@ img {
     justify-content: center;
     align-items: center;
     font-weight: var(--fontweight-light);
-    padding: var(--padding);
     color: var(--color-background);
     line-height: 1;
 
@@ -1657,7 +1685,7 @@ img {
     right: 0;
     z-index: 1000;
     font-size: 0.8rem;
-    padding: var(--padding);
+    padding: var(--padding) var(--edge-padding);
     border-top: var(--line-thickness) solid var(--color-text);
     background-color: var(--color-background);
     filter: drop-shadow(var(--elevation-1));
@@ -1717,8 +1745,8 @@ img {
     grid-template-areas:
         "area0 area0 area0 area0"
         "area1 area2 area3 area4";
-    padding: var(--padding);
-    gap: var(--v-spacing-small) var(--h-spacing-small);
+    padding: var(--edge-padding);
+    gap: var(--v-spacing-half) var(--h-spacing-small);
 }
 
 #image-overlay .wrapper > *:nth-child(1) {
@@ -1760,8 +1788,8 @@ img {
     max-height: calc(
             100vh
             - var(--button-size)
-            - var(--v-spacing-small)
-            - var(--padding) * 2
+            - var(--v-spacing-half)
+            - var(--edge-padding) * 2
             - var(--unit)
             - 1lh
     );
@@ -1804,7 +1832,7 @@ img {
             ". area0 ."
             ". area0 area2"
             ". area0 area3";
-        gap: var(--v-spacing-small) var(--h-spacing-small);
+        gap: var(--v-spacing-half) var(--h-spacing-small);
     }
 
     #image-overlay .wrapper > *:nth-child(1) {
@@ -1832,7 +1860,7 @@ img {
     #image-overlay-img {
         max-height: calc(
                 100vh
-                - var(--padding) * 2
+                - var(--edge-padding) * 2
                 - var(--unit)
                 - 1lh
         );

--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -539,7 +539,6 @@ header.scrolled {
     overflow: hidden;
     max-width: var(--max-site-width, 1920px);
     width: 100%;
-    gap: calc(var(--v-spacing) * 2);
     transition: all 0.3s;
 }
 
@@ -554,8 +553,15 @@ header.scrolled {
 @media screen and (max-width: 945px) {
     .expanded-header:has(.active) {
         height: calc(100dvh - var(--header-height));
+        padding: var(--padding) var(--edge-padding);
         flex-direction: column;
         justify-content: space-between;
+        overflow-y: auto;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+    }
+    .expanded-header::-webkit-scrollbar {
+        display: none;
     }
 }
 
@@ -565,6 +571,7 @@ header.scrolled {
     gap: var(--v-spacing);
     width: 100%;
     justify-content: end;
+    max-height: calc(100dvh - var(--header-height));
 }
 
 .expanded-header > *:not(.active) {
@@ -584,11 +591,8 @@ nav, nav ul {
 }
 
 @media screen and (max-width: 945px) {
-    .expanded-header {
-        padding-top: var(--v-spacing);
-    }
     .expanded-header nav, .expanded-header nav ul {
-        --_nav-spacing: calc(var(--v-spacing));
+        --_nav-spacing: var(--v-spacing);
     }
 }
 
@@ -680,6 +684,10 @@ label:focus-within, label:has(button):hover, label:has(button.active) {
 @media screen and (max-width: 945px) {
     .expanded-menu {
         align-items: center;
+        min-height: 34rem; /* ~ height of hamburger menu */
+    }
+    #preview-search {
+        font-size: var(--font-size-body);
     }
 }
 
@@ -709,11 +717,11 @@ label:focus-within, label:has(button):hover, label:has(button.active) {
     align-items: end;
     gap: calc(var(--v-spacing) / 2);
     margin: 0;
+    font-size: var(--font-size-body);
 }
 
 .sub-menu-heading {
-    font-weight: var(--fontweight-light);
-    font-size: var(--font-size-label);
+    color: var(--color-neutral-500);
 }
 
 .expanded-header .social-media-links {
@@ -1071,8 +1079,10 @@ section#welcome-section {
     justify-content: start;
     align-items: center;
     max-width: 100%;
+    flex-wrap: wrap; /* as long as scrolling does not work */
 }
 
+/* Sadly - this still does not work 
 @media screen and (max-width: 600px) {
     .filter-row {
         overflow-x: auto;
@@ -1090,6 +1100,7 @@ section#welcome-section {
     }
     
 }
+*/
 
 div:has(>.filter-expansion) {
     position: relative;

--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -56,28 +56,7 @@
     --color-lavender-600: #9c68a2;
     --color-lavender-700: #b58bba;
     --color-lavender-900: #e2d0e4;
-}
 
-.minf {
-    --color-primary: var(--color-minf);
-    --color-secondary: var(--color-minf);
-}
-
-.musk {
-    --color-primary: var(--color-musk);
-    --color-secondary: var(--color-musk);
-}
-
-@media (prefers-color-scheme: dark) {
-    :root {
-        --color-background: var(--color-neutral-050);
-        --color-text: var(--color-neutral-900);
-        --color-container: var(--color-neutral-100);
-        --elevation-1: 0px 0px 8px rgba(0, 0, 0, 0.5);
-    }
-}
-
-:root {
     /* Typography */
     --font-family: "Helvetica Neue", "Arial", sans-serif;
     --font-size-mobile: 100%;
@@ -170,6 +149,25 @@
     :root {
         --edge-padding: var(--edge-padding-l);
         --h-spacing: var(--h-spacing-l);
+    }
+}
+
+.minf {
+    --color-primary: var(--color-minf);
+    --color-secondary: var(--color-minf);
+}
+
+.musk {
+    --color-primary: var(--color-musk);
+    --color-secondary: var(--color-musk);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --color-background: var(--color-neutral-050);
+        --color-text: var(--color-neutral-900);
+        --color-container: var(--color-neutral-100);
+        --elevation-1: 0px 0px 4px rgba(0, 0, 0, 0.5);
     }
 }
 

--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -131,8 +131,8 @@
     --h-spacing: var(--h-spacing-s);
     --h-spacing-small: calc(var(--h-spacing) / 2);
 
-    --v-spacing-s: calc(var(--unit) * 7);
-    --v-spacing-l: calc(var(--unit) * 8);
+    --v-spacing-s: calc(var(--unit) * 8);
+    --v-spacing-l: calc(var(--unit) * 9);
 
     --v-spacing: var(--v-spacing-s);
     --v-spacing-half: calc(var(--v-spacing) / 2);
@@ -140,7 +140,7 @@
 
     --section-spacing: calc(var(--v-spacing) * 1.5);
 
-    --v-spacing-previews: calc(var(--v-spacing) * 2);
+    --v-spacing-previews: calc(var(--v-spacing) * 1.5);
 
     --header-height: calc(var(--unit) * 11);
 
@@ -167,7 +167,7 @@
     }
 }
 
-@media (min-width: 930px) {
+@media (min-width: 945px) {
     :root {
         --edge-padding: var(--edge-padding-l);
         --h-spacing: var(--h-spacing-l);
@@ -279,7 +279,7 @@ body {
     }
 }
 
-@media screen and (min-width: 930px) {
+@media screen and (min-width: 945px) {
     .content-grid {
         grid-template-columns: repeat(12, 1fr);
     }
@@ -315,13 +315,13 @@ body {
     }
 }
 
-@media screen and (min-width: 930px) {
+@media screen and (min-width: 945px) {
     .not-large {
         display: none !important;
     }
 }
 
-@media screen and (max-width: 930px) {
+@media screen and (max-width: 945px) {
     .large-only {
         display: none !important;
     }
@@ -515,7 +515,7 @@ header.scrolled {
     --_header-elevation: var(--elevation-1);
 }
 
-@media screen and (min-width: 930px) {
+@media screen and (min-width: 945px) {
     header {
         white-space: nowrap;
     }
@@ -530,7 +530,6 @@ header.scrolled {
     justify-content: space-between;
     align-items: center;
     padding: calc(var(--unit) * 2) var(--edge-padding);
-    gap: var(--v-spacing);
 }
 
 .expanded-header {
@@ -549,10 +548,10 @@ header.scrolled {
     display: flex;
     justify-content: end;
     align-items: end;
-    padding: var(--edge-padding);
+    padding: 0 var(--edge-padding) var(--padding);
 }
 
-@media screen and (max-width: 930px) {
+@media screen and (max-width: 945px) {
     .expanded-header:has(.active) {
         height: calc(100dvh - var(--header-height));
         flex-direction: column;
@@ -584,15 +583,19 @@ nav, nav ul {
     align-items: center;
 }
 
-@media screen and (max-width: 930px) {
+@media screen and (max-width: 945px) {
+    .expanded-header {
+        padding-top: var(--v-spacing);
+    }
     .expanded-header nav, .expanded-header nav ul {
-        --_nav-spacing: calc(var(--v-spacing) * 1.5);
+        --_nav-spacing: calc(var(--v-spacing));
     }
 }
 
 header input[type="search"] {
     --_input-color: var(--_on-header-color);
     --_on-input-color: var(--_on-header-color);
+    width: 100%;
 }
 
 header form {
@@ -618,9 +621,9 @@ input[type="search"]:focus, input[type="number"]:focus, input[type="text"]:focus
     outline: none;
 }
 
-@media screen and (min-width: 930px) {
+@media screen and (min-width: 945px) {
     header form.active input[type="search"] {
-        width: 37.15em; /* Same width as main-menu */
+        width: 38.5em; /* Same width as main-menu */
     }
 }
 
@@ -664,7 +667,7 @@ label:focus-within, label:has(button):hover, label:has(button.active) {
     flex-grow: 1;
 }
 
-@media screen and (min-width: 930px) {
+@media screen and (min-width: 945px) {
     .expanded-header nav {
         flex-grow: inherit;
     }
@@ -674,7 +677,7 @@ label:focus-within, label:has(button):hover, label:has(button.active) {
     align-items: end;
 }
 
-@media screen and (max-width: 930px) {
+@media screen and (max-width: 945px) {
     .expanded-menu {
         align-items: center;
     }
@@ -969,6 +972,7 @@ footer .social-media-links {
 .hero-trailer {
     background: rgb(27, 27, 82);
     width: 100%;
+    min-height: 400px;
     height: 75svh;
     object-fit: cover;
 }
@@ -993,7 +997,7 @@ section.hero.wrapping-grid > .content-grid {
 }
 
 section#welcome-section {
-    margin-top: calc((var(--section-spacing) / -2) - var(--unit));
+    margin-top: calc((var(--section-spacing) * -1) + var(--v-spacing));
 }
 
 .website-title {
@@ -1001,7 +1005,7 @@ section#welcome-section {
     font-size: var(--font-size-title);
     font-weight: var(--fontweight-title);
     line-height: var(--line-height-headline);
-    margin-block: var(--header-height) var(--h-spacing);
+    margin-block: var(--header-height) calc(var(--v-spacing) - 0.1em);
 
     color: var(--color-neutral-1000);
     text-shadow: 0 0 24px black;
@@ -1038,7 +1042,7 @@ section#welcome-section {
     width: 100%;
 }
 
-@media screen and (min-width: 930px) {
+@media screen and (min-width: 945px) {
     .welcome-text {
         grid-column: span 8 !important;
         padding-inline-end: var(--h-spacing);
@@ -1066,6 +1070,25 @@ section#welcome-section {
     gap: calc(var(--unit) * 2);
     justify-content: start;
     align-items: center;
+    max-width: 100%;
+}
+
+@media screen and (max-width: 600px) {
+    .filter-row {
+        overflow-x: auto;
+        padding: var(--unit);
+        margin: calc(var(--unit) * -1);
+        position: relative;
+        isolation: isolate;
+
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+    }
+
+    .filter-row::-webkit-scrollbar {
+        display: none;
+    }
+    
 }
 
 div:has(>.filter-expansion) {
@@ -1089,7 +1112,7 @@ div:has(>.filter-expansion) {
     grid-template-columns: repeat(auto-fit, minmax(var(--_filter-item-width), 1fr));
     justify-items: center;
     align-items: start;
-    gap: var(--v-spacing-previews) var(--h-spacing);
+    gap: var(--v-spacing) var(--h-spacing);
     z-index: 1;
 
     background: var(--_filter-expansion-background);
@@ -1113,13 +1136,13 @@ div:has(>.filter-expansion) {
     display: none;
 }
 
-@media screen and (min-width: 930px) {
+@media screen and (min-width: 945px) {
     .filter-expansion {
         border: var(--line-thickness) solid var(--_filter-expansion-background);
     }
 }
 
-@media screen and (max-width: 930px) {
+@media screen and (max-width: 945px) {
     .filter-expansion {
         --_filter-expansion-background: var(--color-background);
         position: fixed;
@@ -1143,7 +1166,7 @@ div:has(>.filter-expansion) {
     }
 }
 
-@media screen and (min-width: 930px) {
+@media screen and (min-width: 945px) {
     #course-filter {
         grid-template-columns: 1fr 1fr;
     }
@@ -1173,8 +1196,7 @@ div:has(>.filter-expansion) {
 div:has(button.active) .filter-expansion {
     border-top: var(--line-thickness) solid var(--color-primary);
 }
-
-@media screen and (min-width: 930px) {
+@media screen and (min-width: 945px) {
     div:has(button.active) .filter-expansion {
         border: var(--line-thickness) solid var(--color-primary);
     }
@@ -1356,7 +1378,7 @@ label:has(.wheel-select) {
 .preview {
     display: flex;
     flex-direction: column;
-    gap: var(--unit);
+    gap: var(--padding);
     align-content: start;
 }
 
@@ -1380,8 +1402,7 @@ a.preview:hover, a.preview:focus {
     width: 100%;
     background: rgb(44, 17, 70);
     object-fit: cover;
-    min-height: 150px; /* Fallback for browsers that do not support or have not activated javascript*/
-    max-height: 70svh;
+    max-height: 65svh;
 }
 
 .preview .preview-img-wrapper {
@@ -1405,7 +1426,7 @@ a.preview:hover, a.preview:focus {
     content: url("../../resources/imgs/logo_musk_stamp_color.svg");
 }
 
-@media screen and (min-width: 930px) {
+@media screen and (min-width: 945px) {
     .preview .preview-img {
         max-height: 50svh;
     }
@@ -1443,6 +1464,7 @@ a.preview:hover, a.preview:focus {
     gap: calc(var(--unit) * 3);
     justify-content: center;
     align-items: center;
+    flex-wrap: wrap;
 }
 
 .page-nav * {
@@ -1451,8 +1473,8 @@ a.preview:hover, a.preview:focus {
 
 /* beitragsseite */
 
-body:has(*.content-title) section:first-of-type {
-    margin-block-start: var(--header-height);
+body.content-page section:first-of-type {
+    margin-block: var(--header-height) calc((var(--section-spacing) * -1) + var(--v-spacing));
 }
 
 body:not(:has(*.content-title, *.hero)) section:first-of-type {
@@ -1471,11 +1493,11 @@ main.wrapping-grid {
     width: 100%;
     height: 60vh;
     object-fit: cover;
-    margin-block-end: var(--v-spacing);
 }
 
 .title-img-container {
     position: relative;
+    margin-block-end: var(--v-spacing);
 }
 
 /* point of interest system */
@@ -1504,43 +1526,41 @@ img {
     gap: var(--unit) 0;
 }
 
-.content blockquote {
-.content blockquote {
+.content-grid blockquote {
     height: auto;
     display: none;
 }
 
-.content blockquote p {
-.content blockquote p {
+.content-grid blockquote p {
     font-size: 2em;
     font-weight: 100;
     text-indent: 0;
     transform: translateY(calc((1lh - 1em) * -0.8));
 }
 
-@media screen and (min-width: 930px) {
-    .content .inline-img-container {
-    .content .inline-img-container {
+@media screen and (min-width: 945px) {
+    .content-grid .inline-img-container {
         margin: 0;
         grid-column: 2 / -2;
         overflow-x: hidden;
     }
 
-    .content .inline-img-container img {
+    .content-grid .inline-img-container img {
         min-height: 400px;
+        max-height: max(70vh, 400px);
     }
 
-    .content .inline-img-container + blockquote {
+    .content-grid .inline-img-container + blockquote {
         display: block;
     }
 
-    .content .inline-img-container:has(+ .inline-img-container, + blockquote),
-    .content blockquote:has(+ .inline-img-container) {
+    .content-grid .inline-img-container:has(+ .inline-img-container, + blockquote),
+    .content-grid blockquote:has(+ .inline-img-container) {
         grid-column: 2 / span 5;
     }
 
-    .content .inline-img-container + .inline-img-container,
-    .content .inline-img-container + blockquote {
+    .content-grid .inline-img-container + .inline-img-container,
+    .content-grid .inline-img-container + blockquote {
         grid-column: span 5 / -2;
     }
 
@@ -1566,8 +1586,8 @@ img {
     aspect-ratio: 3/2;
 }
 
-@media screen and (min-width: 600px) and (max-width: 930px) {
-    #recommendation-container .preview:nth-of-type(n+3) {
+@media screen and (min-width: 600px) and (max-width: 945px) {
+    #post-browsing-section .preview:nth-of-type(n+3) {
         display: none;
     }
 }
@@ -1623,7 +1643,7 @@ img {
     pointer-events: none;
 }
 
-@media screen and (max-width: 930px) {
+@media screen and (max-width: 945px) {
     #content-gallery:has(.gallery-img:nth-child(5)) .gallery-img:nth-of-type(n+5) {
         display: none;
     }
@@ -1658,7 +1678,7 @@ img {
     }
 }
 
-@media screen and (min-width: 930px) {
+@media screen and (min-width: 945px) {
     #content-gallery:has(.gallery-img:nth-child(7)) .gallery-img:nth-of-type(n+7) {
         display: none;
     }
@@ -1716,7 +1736,7 @@ img {
     gap: 0.5lh;
 }
 
-@media screen and (min-width: 930px) {
+@media screen and (min-width: 945px) {
     #cookies > div {
         flex-direction: row;
     }

--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -688,9 +688,10 @@ label:focus-within, label:has(button):hover, label:has(button.active) {
 }
 
 @media screen and (max-width: 945px) {
-    .expanded-menu {
+    .expanded-menu.active {
         align-items: center;
         min-height: 34rem; /* ~ height of hamburger menu */
+        gap: 0;
     }
     #preview-search {
         font-size: var(--font-size-body);

--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -114,15 +114,12 @@
     --unit: 8px;
 
     --edge-padding-s: calc(var(--unit) * 3);
-    --edge-padding-m: calc(var(--unit) * 4);
+    --edge-padding-m: calc(var(--unit) * 5);
     --edge-padding-l: calc(var(--unit) * 6);
     --edge-padding: var(--edge-padding-s);
 
-    --padding-s: 1em;
-    --padding-m: 2em;
-    --padding-l: 3em;
-
-    --padding: clamp(var(--padding-s), 1vw, var(--padding-l));
+    --padding: 1.5em;
+    --padding-half: calc(var(--padding) / 2);
 
     --h-spacing-s: var(--edge-padding-s);
     --h-spacing-m: var(--edge-padding-m);
@@ -138,9 +135,10 @@
     --v-spacing-half: calc(var(--v-spacing) / 2);
 
 
-    --section-spacing: calc(var(--v-spacing) * 1.5);
+    --section-spacing: calc(var(--v-spacing) * 1.8);
 
     --v-spacing-previews: calc(var(--v-spacing) * 1.5);
+    --v-spacing-previews-grid: calc(var(--v-spacing) * 2);
 
     --header-height: calc(var(--unit) * 11);
 
@@ -162,8 +160,9 @@
     :root {
         --edge-padding: var(--edge-padding-m);
         --h-spacing: var(--h-spacing-m);
-
         --v-spacing: var(--v-spacing-l);
+        --v-spacing-previews: var(var(--v-spacing-previews-grid))
+
     }
 }
 
@@ -229,6 +228,7 @@ body {
             1fr
         )
         [full-end];
+
     gap: var(--section-spacing) 0;
 }
 
@@ -242,6 +242,10 @@ body {
 
 .wrapping-grid > .full {
     grid-column: full;
+}
+
+.wrapping-grid:not(main > .wrapping-grid) {
+    gap: var(--v-spacing) 0;
 }
 
 .content-grid {
@@ -404,17 +408,19 @@ h1 {
 }
 
 h2 {
-    margin-block-start: var(--v-spacing);
     font-size: var(--font-size-headline2);
     font-weight: var(--fontweight-headline);
     line-height: var(--line-height-headline);
 }
 
 h3 {
-    margin-block-start: var(--v-spacing-half);
     font-size: var(--font-size-headline3);
     font-weight: var(--fontweight-headline);
     line-height: var(--line-height-headline);
+}
+
+h2, h3 {
+    margin-block-start: var(--padding);
 }
 
 form {
@@ -1389,12 +1395,12 @@ label:has(.wheel-select) {
 .preview {
     display: flex;
     flex-direction: column;
-    gap: var(--padding);
+    gap: var(--padding-half);
     align-content: start;
 }
 
 .preview:has(*.dummy) {
-    opacity: 20%;
+    opacity: 0.4;
 }
 
 a.preview {
@@ -1426,7 +1432,7 @@ a.preview:hover, a.preview:focus {
     bottom: 0;
     width: 2rem;
     height: 2rem;
-    margin: var(--unit);
+    margin: var(--padding-half);
 }
 
 .preview.minf .preview-img-wrapper::after {
@@ -1496,10 +1502,6 @@ main.wrapping-grid {
     gap: var(--v-spacing) 0;
 }
 
-.content-title.wrapping-grid {
-    gap: var(--unit) 0;
-}
-
 .title-img {
     width: 100%;
     height: 60vh;
@@ -1508,7 +1510,6 @@ main.wrapping-grid {
 
 .title-img-container {
     position: relative;
-    margin-block-end: var(--v-spacing);
 }
 
 /* point of interest system */
@@ -1524,6 +1525,12 @@ img {
     grid-column: 1 / -1;
 }
 
+.content-title-container {
+    display: flex;
+    flex-direction: column;
+    gap: var(--padding-half);
+}
+
 .caption, .caption * {
     font-size: var(--font-size-label);
     font-weight: var(--fontweight-light);
@@ -1534,7 +1541,7 @@ img {
     margin: 0 var(--padding);
     display: flex;
     flex-direction: column;
-    gap: var(--padding) 0;
+    gap: var(--padding-half) 0;
 }
 
 .content-grid blockquote {
@@ -1543,7 +1550,7 @@ img {
 }
 
 .content-grid blockquote p {
-    font-size: 2em;
+    font-size: var(--font-size-headline2);
     font-weight: 100;
     text-indent: 0;
     transform: translateY(calc((1lh - 1em) * -0.8));
@@ -1564,6 +1571,9 @@ img {
     .content-grid .inline-img-container + blockquote {
         display: block;
     }
+    .content-grid blockquote:has(+ .inline-img-container) {
+        display: block;
+    }
 
     .content-grid .inline-img-container:has(+ .inline-img-container, + blockquote),
     .content-grid blockquote:has(+ .inline-img-container) {
@@ -1578,7 +1588,7 @@ img {
 
 }
 
-.inline-img-container > img {
+.inline-img-container img {
     width: 100%;
     height: auto;
     object-fit: cover;
@@ -1822,7 +1832,7 @@ img {
     justify-self: stretch;
     display: flex;
     flex-direction: column;
-    gap: var(--padding);
+    gap: var(--padding-half);
     align-items: center;
     justify-content: center;
     overflow: hidden;
@@ -1864,7 +1874,7 @@ img {
     position: absolute;
     right: 0;
     bottom: 0;
-    margin: var(--unit);
+    margin: var(--padding-half);
 }
 
 @media screen and (orientation: landscape) {

--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -118,9 +118,9 @@
     --edge-padding-l: calc(var(--unit) * 6);
     --edge-padding: var(--edge-padding-s);
 
-    --padding-s: 1rem;
-    --padding-m: 2rem;
-    --padding-l: 3rem;
+    --padding-s: 1em;
+    --padding-m: 2em;
+    --padding-l: 3em;
 
     --padding: clamp(var(--padding-s), 1vw, var(--padding-l));
 
@@ -1534,7 +1534,7 @@ img {
     margin: 0 var(--padding);
     display: flex;
     flex-direction: column;
-    gap: var(--unit) 0;
+    gap: var(--padding) 0;
 }
 
 .content-grid blockquote {
@@ -1822,7 +1822,7 @@ img {
     justify-self: stretch;
     display: flex;
     flex-direction: column;
-    gap: var(--unit);
+    gap: var(--padding);
     align-items: center;
     justify-content: center;
     overflow: hidden;

--- a/lib/css/style.css
+++ b/lib/css/style.css
@@ -131,14 +131,14 @@
     --h-spacing: var(--h-spacing-s);
     --h-spacing-small: calc(var(--h-spacing) / 2);
 
-    --v-spacing-s: calc(var(--unit) * 5);
-    --v-spacing-l: calc(var(--unit) * 6);
+    --v-spacing-s: calc(var(--unit) * 7);
+    --v-spacing-l: calc(var(--unit) * 8);
 
     --v-spacing: var(--v-spacing-s);
     --v-spacing-half: calc(var(--v-spacing) / 2);
 
 
-    --section-spacing: calc(var(--v-spacing) * 2);
+    --section-spacing: calc(var(--v-spacing) * 1.5);
 
     --v-spacing-previews: calc(var(--v-spacing) * 2);
 
@@ -1484,6 +1484,7 @@ img {
     --poi-y: 0.5;
 
     object-position: calc(var(--poi-x, 0.5) * 100%) calc(var(--poi-y, 0.5) * 100%);
+    object-fit: cover;
 }
 
 .content-grid > * {
@@ -1504,10 +1505,12 @@ img {
 }
 
 .content blockquote {
+.content blockquote {
     height: auto;
     display: none;
 }
 
+.content blockquote p {
 .content blockquote p {
     font-size: 2em;
     font-weight: 100;
@@ -1517,19 +1520,31 @@ img {
 
 @media screen and (min-width: 930px) {
     .content .inline-img-container {
+    .content .inline-img-container {
         margin: 0;
         grid-column: 2 / -2;
+        overflow-x: hidden;
+    }
+
+    .content .inline-img-container img {
+        min-height: 400px;
     }
 
     .content .inline-img-container + blockquote {
         display: block;
     }
 
-    .content .inline-img-container:has(+ .inline-img-container, + blockquote) ,
+    .content .inline-img-container:has(+ .inline-img-container, + blockquote),
+    .content blockquote:has(+ .inline-img-container) {
+        grid-column: 2 / span 5;
+    }
+
     .content .inline-img-container + .inline-img-container,
     .content .inline-img-container + blockquote {
-        grid-column: span 6;
+        grid-column: span 5 / -2;
     }
+
+
 }
 
 .inline-img-container > img {

--- a/lib/javascript/sharePage.js
+++ b/lib/javascript/sharePage.js
@@ -17,7 +17,6 @@ shareButton.addEventListener("click", async () => {
 function snackBar(msg, duration) {
     let elem = document.createElement("div");
     elem.classList.add("snack-bar");
-    elem.setAttribute("style", "z-index: 2;")
     let elemText = document.createElement("p");
     elemText.innerHTML = msg;
 

--- a/pages/beitrag.html
+++ b/pages/beitrag.html
@@ -237,10 +237,8 @@
                     <div id="more-imgs"><span>+<span id="more-img-indicator">2</span></span></div>
                 </div>
             </section>
-            <section>
-                <p id="content-tags"><b>Tags: </b><span id="no-tags">keine</span></p>
-            </section>
             <section class="post-browsing anchor" id="post-browsing-section">
+                <p id="content-tags"><b>Tags: </b><span id="no-tags">keine</span></p>
                 <div class="line"></div>
                 <div class="post-nav">
                     <a id="prev-post">

--- a/pages/beitrag.html
+++ b/pages/beitrag.html
@@ -224,8 +224,10 @@
                         </svg>
                     </button>
                 </div>
-                <h1 class="content-title" id="content-title"></h1>
-                <p class="caption"><span id="content-author"></span> | <span id="content-date"></span></p>
+                <div class="content-title-container">
+                    <h1 class="content-title" id="content-title"></h1>
+                    <p class="caption"><span id="content-author"></span> | <span id="content-date"></span></p>
+                </div>
             </section>
             <section class="content content-grid anchor" id="content-section">
             </section>

--- a/pages/info-help.html
+++ b/pages/info-help.html
@@ -213,6 +213,7 @@
             <section class="content-grid anchor" id="main-section">
                 <ul class="content-table caption">
                     <li><a href="#info-bewerber">Informationen für Bewerber</a></li>
+                    <li><a href="#medienleihe">Medienleihe</a></li>
                     <li><a href="#rundfuehrung">Labore und Rundführung</a></li>
                     <li><a href="#kontakt">Kontakt</a></li>
                 </ul>
@@ -221,6 +222,8 @@
             <section class="content-grid anchor" id="info-bewerber">
                 <h2>Informationen für Bewerber</h2>
                 <p><a href="https://www.hs-harz.de/bewerbungsinformationen">Bewerber*innen</a></p>
+            </section>
+            <section class="content-grid anchor" id="medienleihe">
                 <h2>Medienleihe</h2>
                 <div class="span">
                     <p>Die Medienleihe ist ein Service der Hochschule Harz, der es Studierenden der Studiengänge
@@ -253,7 +256,7 @@
             </section>
             <section class="content-grid anchor" id="kontakt">
                 <h2>Kontakt</h2>
-                <div class="span">
+                <div>
                     <p>Du hast Fragen zu den Studiengängen? Dann wende Dich doch an unsere jeweiligen
                         Studiengangskoordinatoren:</p>
                 </div>


### PR DESCRIPTION
- fixed #19 
  - most spacings are increased
  - spacings are more dependant on oneanother
- implemented #89 
- fixed #103 

- cascading inline images (and blockquotes) now align to correct grid
- font size is now determined by user preferences (mobile 100%, bigger 110%)
- fixed website layout breaking under 350px viewport width
  - filter row and page-nav now wrap (because scrolliing does not work reliably
- added constraints to images, hero-trailer and hamburger-menu
  - should fix overflows on small heights (e.g. portait phones)
  - hamburger menu now scrolls vertically when viewport is too short

there are gonna be some problems when merging with #105 
#105 added passages using old variable-names (-> manual merge required!)
